### PR TITLE
hyperscreaming

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,12 @@ fn repeated(c: u8) -> String {
     String::from_utf8(iter::repeat(c).take(10000).collect()).unwrap()
 }
 
+fn gen_random() -> String {
+    (0..100000u64).map(|i|
+        (i.wrapping_mul(6364136223846793005) >> 56) as u8 as char
+    ).collect()
+}
+
 fn count_newlines(s: &str) -> usize {
     s.as_bytes().iter().filter(|&&c| c == b'\n').count()
 }
@@ -18,6 +24,9 @@ fn count_newlines(s: &str) -> usize {
 const LO : usize = ::std::usize::MAX / 255;
 const HI : usize = LO * 128;
 const REP_NEWLINE : usize = b'\n' as usize * LO;
+
+const EVERY_OTHER_BYTE_LO : usize = 0x0001000100010001;
+const EVERY_OTHER_BYTE : usize = EVERY_OTHER_BYTE_LO * 0xFF;
 
 fn count_newlines_fast(s: &str) -> usize {
     fn count_zero_bytes(x: usize) -> usize {
@@ -233,6 +242,101 @@ fn count_newlines_screaming(s: &str) -> usize {
     count + text[offset..].iter().filter(|b| **b == b'\n').count()
 }
 
+fn count_newlines_hyperscreaming(s: &str) -> usize {
+    unsafe {
+        let text = s.as_bytes();
+        let mut ptr = text.as_ptr();
+        let mut end = ptr.offset(text.len() as isize);
+
+        let mut count = 0;
+
+        // Align start
+        while (ptr as usize) & (USIZE_BYTES - 1) != 0 {
+            if ptr == end {
+                return count;
+            }
+            count += (*ptr == b'\n') as usize;
+            ptr = ptr.offset(1);
+        }
+
+        // Align end
+        while (end as usize) & (USIZE_BYTES - 1) != 0 {
+            end = end.offset(-1);
+            count += (*end == b'\n') as usize;
+        }
+        if ptr == end {
+            return count;
+        }
+
+        // Read in aligned blocks
+        let mut ptr = ptr as *const usize;
+        let end = end as *const usize;
+
+        unsafe fn next(ptr: &mut *const usize) -> usize {
+            let ret = **ptr;
+            *ptr = ptr.offset(1);
+            ret
+        }
+
+        fn mask_zero(x: usize) -> usize {
+            (((x ^ REP_NEWLINE).wrapping_sub(LO)) & !x & HI) >> 7
+        }
+
+        unsafe fn next_4(ptr: &mut *const usize) -> [usize; 4] {
+            let x = [next(ptr), next(ptr), next(ptr), next(ptr)];
+            [mask_zero(x[0]), mask_zero(x[1]), mask_zero(x[2]), mask_zero(x[3])]
+        };
+
+        fn reduce_counts(counts: usize) -> usize {
+            let pair_sum = (counts & EVERY_OTHER_BYTE) + ((counts >> 8) & EVERY_OTHER_BYTE);
+            pair_sum.wrapping_mul(EVERY_OTHER_BYTE_LO) >> ((USIZE_BYTES - 2) * 8)
+        }
+
+        fn arr_add(xs: [usize; 4], ys: [usize; 4]) -> [usize; 4] {
+            [xs[0]+ys[0], xs[1]+ys[1], xs[2]+ys[2], xs[3]+ys[3]]
+        }
+
+        // 8kB
+        while ptr.offset(4 * 255) <= end {
+            let mut counts = [0, 0, 0, 0];
+            for _ in 0..255 {
+                counts = arr_add(counts, next_4(&mut ptr));
+            }
+            count += reduce_counts(counts[0]);
+            count += reduce_counts(counts[1]);
+            count += reduce_counts(counts[2]);
+            count += reduce_counts(counts[3]);
+        }
+
+        // 1kB
+        while ptr.offset(4 * 32) <= end {
+            let mut counts = [0, 0, 0, 0];
+            for _ in 0..32 {
+                counts = arr_add(counts, next_4(&mut ptr));
+            }
+            count += reduce_counts(counts[0] + counts[1] + counts[2] + counts[3]);
+        }
+
+        // 64B
+        let mut counts = [0, 0, 0, 0];
+        while ptr.offset(4 * 2) <= end {
+            for _ in 0..2 {
+                counts = arr_add(counts, next_4(&mut ptr));
+            }
+        }
+        count += reduce_counts(counts[0] + counts[1] + counts[2] + counts[3]);
+
+        // 8B
+        let mut counts = 0;
+        while ptr < end {
+            counts += mask_zero(next(&mut ptr));
+        }
+        count += reduce_counts(counts);
+
+        count
+    }
+}
+
 #[bench]
 fn test_slow_nonewlines(b: &mut test::Bencher) {
     let data = repeated(b'n');
@@ -261,6 +365,12 @@ fn test_fastest_nonewlines(b: &mut test::Bencher) {
 fn test_screaming_nonewlines(b: &mut test::Bencher) {
     let data = repeated(b'n');
     b.iter(move|| count_newlines_screaming(&data))
+}
+
+#[bench]
+fn test_hyperscreaming_nonewlines(b: &mut test::Bencher) {
+    let data = repeated(b'n');
+    b.iter(move|| count_newlines_hyperscreaming(&data))
 }
 
 #[bench]
@@ -295,6 +405,12 @@ fn test_screaming_newlines(b: &mut test::Bencher) {
 }
 
 #[bench]
+fn test_hyperscreaming_newlines(b: &mut test::Bencher) {
+    let data = repeated(b'\n');
+    b.iter(move|| count_newlines_hyperscreaming(&data))
+}
+
+#[bench]
 fn test_slow_somenewlines(b: &mut test::Bencher) {
     let data = "abcd\nbcda\ncdab\ndabc\n\nbc\na\n\nd\n\nc\na\nc\n\n\n\n\nx";
     b.iter(move|| count_newlines(data))
@@ -324,6 +440,49 @@ fn test_screaming_somenewlines(b: &mut test::Bencher) {
     b.iter(move|| count_newlines_screaming(data))
 }
 
+#[bench]
+fn test_hyperscreaming_somenewlines(b: &mut test::Bencher) {
+    let data = "abcd\nbcda\ncdab\ndabc\n\nbc\na\n\nd\n\nc\na\nc\n\n\n\n\nx";
+    b.iter(move|| count_newlines_hyperscreaming(data))
+}
+
+
+#[bench]
+fn test_slow_random(b: &mut test::Bencher) {
+    let data = &gen_random();
+    b.iter(move|| count_newlines(data))
+}
+
+#[bench]
+fn test_fast_random(b: &mut test::Bencher) {
+    let data = &gen_random();
+    b.iter(move|| count_newlines_fast(data))
+}
+
+#[bench]
+fn test_faster_random(b: &mut test::Bencher) {
+    let data = &gen_random();
+    b.iter(move|| count_newlines_faster(data))
+}
+
+#[bench]
+fn test_fastest_random(b: &mut test::Bencher) {
+    let data = &gen_random();
+    b.iter(move|| count_newlines_fastest(data))
+}
+
+#[bench]
+fn test_screaming_random(b: &mut test::Bencher) {
+    let data = &gen_random();
+    b.iter(move|| count_newlines_screaming(data))
+}
+
+#[bench]
+fn test_hyperscreaming_random(b: &mut test::Bencher) {
+    let data = &gen_random();
+    b.iter(move|| count_newlines_hyperscreaming(data))
+}
+
 
 #[test]
 fn check() {
@@ -332,14 +491,23 @@ fn check() {
     assert_eq!(count_newlines(&nonewlines), count_newlines_faster(&nonewlines));
     assert_eq!(count_newlines(&nonewlines), count_newlines_fastest(&nonewlines));
     assert_eq!(count_newlines(&nonewlines), count_newlines_screaming(&nonewlines));
+    assert_eq!(count_newlines(&nonewlines), count_newlines_hyperscreaming(&nonewlines));
     let newlines = repeated(b'\n');
     assert_eq!(count_newlines(&newlines), count_newlines_fast(&newlines));
     assert_eq!(count_newlines(&newlines), count_newlines_faster(&newlines));
     assert_eq!(count_newlines(&newlines), count_newlines_fastest(&newlines));
     assert_eq!(count_newlines(&newlines), count_newlines_screaming(&newlines));
+    assert_eq!(count_newlines(&newlines), count_newlines_hyperscreaming(&newlines));
     let somenewlines = "abcd\nbcda\ncdab\ndabc\n\nbc\na\n\nd\n\nc\na\nc\n\n\n\n\nx";
     assert_eq!(count_newlines(somenewlines), count_newlines_fast(somenewlines));
     assert_eq!(count_newlines(somenewlines), count_newlines_faster(somenewlines));
     assert_eq!(count_newlines(somenewlines), count_newlines_fastest(somenewlines));
     assert_eq!(count_newlines(somenewlines), count_newlines_screaming(somenewlines));
+    assert_eq!(count_newlines(somenewlines), count_newlines_hyperscreaming(somenewlines));
+    let random = &gen_random();
+    assert_eq!(count_newlines(random), count_newlines_fast(random));
+    assert_eq!(count_newlines(random), count_newlines_faster(random));
+    assert_eq!(count_newlines(random), count_newlines_fastest(random));
+    assert_eq!(count_newlines(random), count_newlines_screaming(random));
+    assert_eq!(count_newlines(random), count_newlines_hyperscreaming(random));
 }


### PR DESCRIPTION
This code is sufficiently evil that chances are there's something horribly wrong with it, but it is fast.

With `target-cpu=native`:

```
slow            somenewlines         29 ns/iter (+/- 1)         322%
slow            nonewlines        4,042 ns/iter (+/- 285)      1050%
slow            newlines          5,738 ns/iter (+/- 362)      1490%
slow            random           63,424 ns/iter (+/- 17,382)   1093%

fast            somenewlines         14 ns/iter (+/- 0)         156%
fast            nonewlines        1,848 ns/iter (+/- 114)       480%
fast            newlines          1,886 ns/iter (+/- 106)       490%
fast            random           27,614 ns/iter (+/- 1,642)     476%

screaming       somenewlines          8 ns/iter (+/- 0)          89%
screaming       nonewlines          946 ns/iter (+/- 70)        246%
screaming       newlines            950 ns/iter (+/- 34)        247%
screaming       random           14,076 ns/iter (+/- 880)       243%

faster          somenewlines         11 ns/iter (+/- 0)         122%
faster          nonewlines          882 ns/iter (+/- 347)       229%
faster          newlines            837 ns/iter (+/- 54)        217%
faster          random           12,481 ns/iter (+/- 701)       215%

fastest         somenewlines          6 ns/iter (+/- 0)          67%
fastest         nonewlines          786 ns/iter (+/- 46)        204%
fastest         newlines            786 ns/iter (+/- 48)        204%
fastest         random           12,130 ns/iter (+/- 754)       209%

hyperscreaming  somenewlines          9 ns/iter (+/- 1)         100%
hyperscreaming  nonewlines          385 ns/iter (+/- 32)        100%
hyperscreaming  newlines            385 ns/iter (+/- 40)        100%
hyperscreaming  random            5,802 ns/iter (+/- 326)       100%
```

Without `target-cpu=native`:

```
slow            somenewlines         27 ns/iter (+/- 1)         300%
slow            nonewlines        3,137 ns/iter (+/- 81)        500%
slow            newlines          5,738 ns/iter (+/- 595)       939%
slow            random           63,574 ns/iter (+/- 3,765)     662%

faster          somenewlines         17 ns/iter (+/- 1)         189%
faster          nonewlines        2,462 ns/iter (+/- 153)       392%
faster          newlines          2,463 ns/iter (+/- 176)       403%
faster          random           36,772 ns/iter (+/- 1,864)     383%

fast            somenewlines         14 ns/iter (+/- 1)         156%
fast            nonewlines        1,827 ns/iter (+/- 375)       291%
fast            newlines          1,883 ns/iter (+/- 492)       308%
fast            random           26,978 ns/iter (+/- 1,747)     281%

fastest         somenewlines         11 ns/iter (+/- 0)         122%
fastest         nonewlines        1,093 ns/iter (+/- 61)        174%
fastest         newlines          1,063 ns/iter (+/- 65)        174%
fastest         random           16,089 ns/iter (+/- 855)       168%

screaming       somenewlines          8 ns/iter (+/- 0)          89%
screaming       nonewlines          946 ns/iter (+/- 57)        151%
screaming       newlines            946 ns/iter (+/- 64)        155%
screaming       random           14,104 ns/iter (+/- 793)       147%

hyperscreaming  somenewlines          9 ns/iter (+/- 0)         100%
hyperscreaming  nonewlines          628 ns/iter (+/- 37)        100%
hyperscreaming  newlines            611 ns/iter (+/- 50)        100%
hyperscreaming  random            9,599 ns/iter (+/- 764)       100%
```

LLVM never vectorized well, but given there's an implicit `usize` of vectorization I don't suppose it matters too much. I could probably make it a fair bit faster if I wrote vector code directly, but that'd be even more fragile.
